### PR TITLE
Add WASM support and LIBRARY_ONLY build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_policy(SET CMP0042 NEW)
 
 option(STATIC_BINARIES "Link binaries statically." ON)
 option(USE_SORELEASE   "Use SORELEASE in shared library filename." ON)
+option(LIBRARY_ONLY "Build only minisat library (ZLIB not needed- dependents require -DMINISAT_LIBRARY_ONLY)" OFF)
 
 #--------------------------------------------------------------------------------------------------
 # Library version:
@@ -26,14 +27,23 @@ set(MINISAT_SOVERSION ${MINISAT_SOMAJOR})
 #--------------------------------------------------------------------------------------------------
 # Dependencies:
 
-find_package(ZLIB)
-include_directories(${ZLIB_INCLUDE_DIR})
+if(LIBRARY_ONLY)
+  add_definitions(-DMINISAT_LIBRARY_ONLY)
+else()
+  find_package(ZLIB)
+  include_directories(${ZLIB_INCLUDE_DIR})
+endif()
+
 include_directories(${minisat_SOURCE_DIR})
 
 #--------------------------------------------------------------------------------------------------
 # Compile flags:
 
 add_definitions(-D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS)
+
+if(WASI)
+  add_definitions(-D_WASI_EMULATED_PROCESS_CLOCKS -D_WASI_EMULATED_SIGNAL)
+endif()
 
 #--------------------------------------------------------------------------------------------------
 # Build Targets:
@@ -45,38 +55,66 @@ set(MINISAT_LIB_SOURCES
     minisat/simp/SimpSolver.cc)
 
 add_library(minisat-lib-static STATIC ${MINISAT_LIB_SOURCES})
-add_library(minisat-lib-shared SHARED ${MINISAT_LIB_SOURCES})
+if(NOT WASI)
+  add_library(minisat-lib-shared SHARED ${MINISAT_LIB_SOURCES})
+endif()
 
-target_link_libraries(minisat-lib-shared ${ZLIB_LIBRARY})
+if(NOT WASI)
+  target_link_libraries(minisat-lib-shared ${ZLIB_LIBRARY})
+endif()
 target_link_libraries(minisat-lib-static ${ZLIB_LIBRARY})
 
-add_executable(minisat_core minisat/core/Main.cc)
-add_executable(minisat_simp minisat/simp/Main.cc)
+if(NOT LIBRARY_ONLY)
+  if(WASI)
+    message(FATAL_ERROR "WASI build of MiniSAT does not support binaries yet.")
+  endif()
 
-if(STATIC_BINARIES)
-  target_link_libraries(minisat_core minisat-lib-static)
-  target_link_libraries(minisat_simp minisat-lib-static)
-else()
-  target_link_libraries(minisat_core minisat-lib-shared)
-  target_link_libraries(minisat_simp minisat-lib-shared)
+  add_executable(minisat_core minisat/core/Main.cc)
+  add_executable(minisat_simp minisat/simp/Main.cc)
+
+  if(STATIC_BINARIES)
+    target_link_libraries(minisat_core minisat-lib-static)
+    target_link_libraries(minisat_simp minisat-lib-static)
+  else()
+    target_link_libraries(minisat_core minisat-lib-shared)
+    target_link_libraries(minisat_simp minisat-lib-shared)
+  endif()
 endif()
 
 set_target_properties(minisat-lib-static PROPERTIES OUTPUT_NAME "minisat")
-set_target_properties(minisat-lib-shared
-  PROPERTIES
-    OUTPUT_NAME "minisat" 
-    VERSION ${MINISAT_VERSION}
-    SOVERSION ${MINISAT_SOVERSION})
+if(NOT WASI)
+  set_target_properties(minisat-lib-shared
+    PROPERTIES
+      OUTPUT_NAME "minisat"
+      VERSION ${MINISAT_VERSION}
+      SOVERSION ${MINISAT_SOVERSION})
+endif()
 
-set_target_properties(minisat_simp       PROPERTIES OUTPUT_NAME "minisat")
+if(NOT LIBRARY_ONLY)
+  set_target_properties(minisat_simp       PROPERTIES OUTPUT_NAME "minisat")
+endif()
 
 #--------------------------------------------------------------------------------------------------
 # Installation targets:
 
-install(TARGETS minisat-lib-static minisat-lib-shared minisat_core minisat_simp 
+install(TARGETS minisat-lib-static
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
+
+if(NOT WASI)
+  install(TARGETS minisat-lib-shared
+          RUNTIME DESTINATION bin
+          LIBRARY DESTINATION lib
+          ARCHIVE DESTINATION lib)
+endif()
+
+if(NOT LIBRARY_ONLY)
+  install(TARGETS minisat_core minisat_simp
+          RUNTIME DESTINATION bin
+          LIBRARY DESTINATION lib
+          ARCHIVE DESTINATION lib)
+endif()
 
 install(DIRECTORY minisat/mtl minisat/utils minisat/core minisat/simp
         DESTINATION include/minisat

--- a/minisat/core/Main.cc
+++ b/minisat/core/Main.cc
@@ -18,6 +18,10 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+#ifdef MINISAT_LIBRARY_ONLY
+    #error MiniSAT binaries are unavailable when MINISAT_LIBRARY_ONLY is defined
+#endif
+
 #include <errno.h>
 #include <zlib.h>
 

--- a/minisat/simp/Main.cc
+++ b/minisat/simp/Main.cc
@@ -18,6 +18,10 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+#ifdef MINISAT_LIBRARY_ONLY
+    #error MiniSAT binaries are unavailable when MINISAT_LIBRARY_ONLY is defined
+#endif
+
 #include <errno.h>
 #include <zlib.h>
 

--- a/minisat/utils/System.cc
+++ b/minisat/utils/System.cc
@@ -106,7 +106,7 @@ void Minisat::setX86FPUPrecision()
 }
 
 
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
+#if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__wasm)
 void Minisat::limitMemory(uint64_t max_mem_mb)
 {
 // FIXME: OpenBSD does not support RLIMIT_AS. Not sure how well RLIMIT_DATA works instead.
@@ -138,7 +138,7 @@ void Minisat::limitMemory(uint64_t /*max_mem_mb*/)
 #endif
 
 
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
+#if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__wasm)
 void Minisat::limitTime(uint32_t max_cpu_time)
 {
     if (max_cpu_time != 0){

--- a/minisat/utils/System.h
+++ b/minisat/utils/System.h
@@ -52,7 +52,7 @@ extern void   sigTerm(void handler(int));      // Set up handling of available t
 //-------------------------------------------------------------------------------------------------
 // Implementation of inline functions:
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__wasm)
 #include <time.h>
 
 static inline double Minisat::cpuTime(void) { return (double)clock() / CLOCKS_PER_SEC; }


### PR DESCRIPTION
I've been using [boolector with WASM](https://github.com/YoWASP/boolector), and boolector itself requires a SAT solver. I originally compiled `yowasp-boolector` with PicoSAT, but its performance ended up being unacceptable for many "real" problems.

I got MiniSAT to work w/ boolector instead. This patch adds the necessary code to make a WASM play nice w/ MiniSAT. Specifically, no binaries, and no ZLIB since they're only used by the binaries to parse DIMACS files.